### PR TITLE
Fix Missing Curly Brackets Symbols

### DIFF
--- a/modules/cyk.py
+++ b/modules/cyk.py
@@ -175,7 +175,7 @@ def get_table_element(inputString):
             if len(res) == 0:
                 temp.append("\u2205")
             else:
-                temp.append(", ".join(res))
+                temp.append("{" + ", ".join(res) + "}")
         result.append(temp)
     result.append(inputString.split(" "))
     return result


### PR DESCRIPTION
## Description

Closes #7 

I have fix the bug when the curly brackets symbols is missing in triangular table.

## Type of Change

- [x] Bug fix

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
